### PR TITLE
[feat/#3] 미션 위치 제공 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-pool2'
 	implementation 'org.springframework.session:spring-session-jdbc'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/likelion/traditional_market/controller/LocationController.java
+++ b/src/main/java/likelion/traditional_market/controller/LocationController.java
@@ -1,0 +1,34 @@
+package likelion.traditional_market.controller;
+
+import likelion.traditional_market.dto.MissionRequestDto;
+import likelion.traditional_market.dto.StoreInfoDto;
+import likelion.traditional_market.service.LocationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/story")
+@RequiredArgsConstructor
+public class LocationController {
+    private final LocationService locationService;
+    @PostMapping("/location")
+    public ResponseEntity<Map<String, List<StoreInfoDto>>>
+
+    getMissionStores(@RequestBody MissionRequestDto request){
+//        실제 db데이터 호출할때 사용할 코드_Mock데이터 호출시 주석처리해야함
+        Map<String, List<StoreInfoDto>> response =
+                locationService.getStoreInfo(request.getUserKey());
+
+//      Mock데이터 호출_db연결 시 삭제
+//      Map<String, List<StoreInfoDto>> response =
+//              locationService.getMockStoreInfo(request.getUserKey());
+
+        return ResponseEntity.ok(response);
+        }
+}

--- a/src/main/java/likelion/traditional_market/dto/MissionRequestDto.java
+++ b/src/main/java/likelion/traditional_market/dto/MissionRequestDto.java
@@ -1,0 +1,12 @@
+package likelion.traditional_market.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class MissionRequestDto {
+    private String userKey;
+}

--- a/src/main/java/likelion/traditional_market/dto/StoreInfoDto.java
+++ b/src/main/java/likelion/traditional_market/dto/StoreInfoDto.java
@@ -1,0 +1,17 @@
+package likelion.traditional_market.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.Getter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StoreInfoDto {
+    private String name;
+    private String address;
+    private String phoneNumber;
+    private String x;
+    private String y;
+
+}

--- a/src/main/java/likelion/traditional_market/entity/Mission.java
+++ b/src/main/java/likelion/traditional_market/entity/Mission.java
@@ -1,0 +1,15 @@
+package likelion.traditional_market.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Mission {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY) // User와 N:1 관계
+    @JoinColumn(name = "user_id", nullable = false) // FK 컬럼명 지정
+    private User user;
+}

--- a/src/main/java/likelion/traditional_market/entity/MissionItem.java
+++ b/src/main/java/likelion/traditional_market/entity/MissionItem.java
@@ -1,0 +1,17 @@
+package likelion.traditional_market.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class MissionItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="mission_id")
+    private Mission mission;
+    @Column(name="item_name",nullable=false)
+    private String itemName;
+}

--- a/src/main/java/likelion/traditional_market/entity/User.java
+++ b/src/main/java/likelion/traditional_market/entity/User.java
@@ -1,0 +1,16 @@
+package likelion.traditional_market.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+
+public class User {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @Getter
+    private String userKey;
+}

--- a/src/main/java/likelion/traditional_market/repository/MissionRepository.java
+++ b/src/main/java/likelion/traditional_market/repository/MissionRepository.java
@@ -1,0 +1,10 @@
+package likelion.traditional_market.repository;
+
+import likelion.traditional_market.entity.MissionItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MissionRepository extends JpaRepository<MissionItem,Long> {
+    List<MissionItem> findByMission_User_UserKey(String userkey);
+}

--- a/src/main/java/likelion/traditional_market/service/LocationService.java
+++ b/src/main/java/likelion/traditional_market/service/LocationService.java
@@ -1,0 +1,84 @@
+package likelion.traditional_market.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import likelion.traditional_market.dto.StoreInfoDto;
+import likelion.traditional_market.entity.MissionItem;
+import likelion.traditional_market.repository.MissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+    @Value("${kakao.api.key}")
+    private String kakaoapikey;
+    private static final String BASE_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
+    private final MissionRepository missionRepository;
+
+    public Map<String,List<StoreInfoDto>> getStoreInfo(String userKey){
+        List<MissionItem> items = missionRepository.findByMission_User_UserKey(userKey);
+        Map<String,List<StoreInfoDto>> result = new LinkedHashMap<>();
+        for(MissionItem item:items){
+            List<StoreInfoDto> stores = searchStores(item.getItemName());
+            result.put(item.getItemName(),stores);
+        }
+        return result;
+    }
+
+    public List<StoreInfoDto> searchStores(String keyword){
+    WebClient client = WebClient.builder()
+            .baseUrl(BASE_URL)
+            .defaultHeader("Authorization", "KakaoAK " + kakaoapikey)
+            .build();
+        String response = client.get()
+                .uri(uriBuilder -> uriBuilder.queryParam("query", keyword).build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+        return parseResponse(response);
+    }
+
+    private List<StoreInfoDto> parseResponse(String jsonResponse) {
+        ObjectMapper mapper = new ObjectMapper();
+        List<StoreInfoDto> result = new ArrayList<>();
+        try {
+            JsonNode root = mapper.readTree(jsonResponse);
+            JsonNode documents = root.get("documents");
+
+            for (JsonNode doc : documents) {
+                result.add(new StoreInfoDto(
+                        doc.get("place_name").asText(),
+                        doc.get("address_name").asText(),
+                        doc.hasNonNull("phone") ? doc.get("phone").asText() : "정보 없음",
+                        doc.get("x").asText(),
+                        doc.get("y").asText()
+                ));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+//    Mock데이터_DB연동 시 제거_Postman확인용
+//    public Map<String, List<StoreInfoDto>> getMockStoreInfo(String userKey) {
+//        Map<String, List<StoreInfoDto>> mockData = new LinkedHashMap<>();
+//        List<StoreInfoDto> appleStores = List.of(
+//                new StoreInfoDto("사과가게1", "서울시 중구", "010-1234-5678", "127.001", "37.501"),
+//                new StoreInfoDto("사과가게2", "서울시 종로구", "010-9876-5432", "127.002", "37.502")
+//        );
+//        List<StoreInfoDto> bananaStores = List.of(
+//                new StoreInfoDto("바나나가게1", "서울시 강남구", "010-0000-1111", "127.003", "37.503")
+//        );
+//        mockData.put("사과", appleStores);
+//        mockData.put("바나나", bananaStores);
+//        return mockData;
+//    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #3

## 📄 작업 내용

- 카카오맵 API 연동 : 미션 아이템 판매 점포 검색 기능
- Postman 테스트용 Mock 메서드 작성 (현재 주석 처리 상태)
- build.gradle에 WebFlux 의존성 추가
- implementation 'org.springframework.boot:spring-boot-starter-webflux'

## 💻 주요 코드 설명

- 카카오맵 API 검색 기능
- WebClient를 이용해 카카오맵API 호출
- JSON 응답 파싱하여 StoreInfoDto 리스트로 변환
- MissionRepository를 통해 유저 키 기반 미션 아이템 목록을 조회함

<details>
<summary>LocationService</summary>

```swift
public Map<String,List<StoreInfoDto>> getStoreInfo(String userKey){
        List<MissionItem> items = missionRepository.findByMission_User_UserKey(userKey);
        Map<String,List<StoreInfoDto>> result = new LinkedHashMap<>();
        for(MissionItem item:items){
            List<StoreInfoDto> stores = searchStores(item.getItemName());
            result.put(item.getItemName(),stores);
        }
        return result;
    }
```
</details>


## 👀 기타 더 이야기해볼 점

- 현재 DB 미연동 상태 --> Mock 메서드 사용

- 추후 DB스키마 생성 후 :
mission_item 및 관련 테이블 생성 -> Mock 메서드 삭제 ->
Controller에서 getStoreInfo()로 교체 (주석 달린 코드만 삭제하면 됩니다) 
